### PR TITLE
Use fetch2 from JitPack instead of JCenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     if (project.properties['android.useAndroidX'] == 'true' || project.properties['android.useAndroidX'] == true) {
-        api "androidx.tonyodev.fetch2:xfetch2:3.1.6"
-        implementation "androidx.tonyodev.fetch2okhttp:xfetch2okhttp:3.1.6"
+        api "com.github.tonyofrancis.Fetch:xfetch2:3.1.6"
+        implementation "com.github.tonyofrancis.Fetch:xfetch2okhttp:3.1.6"
     } else {
         api "com.tonyodev.fetch2:fetch2:3.0.12"
         implementation "com.tonyodev.fetch2okhttp:fetch2okhttp:3.0.12"


### PR DESCRIPTION
This could be a breaking change if the user using this package only has JCenter and doesn't have JitPack. However, JCenter is deprecated and no longer included as one of the default repositories.