### PR TITLE
Android download complete location support added.

### DIFF
--- a/android/src/main/java/com/eko/RNBGDTaskConfig.java
+++ b/android/src/main/java/com/eko/RNBGDTaskConfig.java
@@ -4,11 +4,13 @@ import java.io.Serializable;
 
 public class RNBGDTaskConfig implements Serializable {
     public String id;
+    public String destination;
     public String metadata;
     public boolean reportedBegin;
 
-    public RNBGDTaskConfig(String id, String metadata) {
+    public RNBGDTaskConfig(String id, String destination, String metadata) {
         this.id = id;
+        this.destination = destination;
         this.metadata = metadata;
         this.reportedBegin = false;
     }

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -211,7 +211,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
       return;
     }
 
-    RNBGDTaskConfig config = new RNBGDTaskConfig(id, metadata);
+    RNBGDTaskConfig config = new RNBGDTaskConfig(id, destination, metadata);
     final Request request = new Request(url, destination);
     if (headers != null) {
       ReadableMapKeySetIterator it = headers.keySetIterator();
@@ -330,8 +330,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule imp
       if (config != null) {
         WritableMap params = Arguments.createMap();
         params.putString("id", config.id);
-
-        // TODO: add location
+        params.putString("location", config.destination);
 
         ee.emit("downloadComplete", params);
       }

--- a/react-native-background-downloader.podspec
+++ b/react-native-background-downloader.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m}'
   s.requires_arc = true
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
After the download is complete on the Android side, the location information cannot be returned.
This support is available on the iOS side.
It is indicated as "**TODO**" in the source codes. Adding support for it.

**Briefly;**
```
RNBackgroundDownloader
      .download({
        id: id,
        url: url,
        destination: destination
      })
      .begin(process => {})
      .progress(percent => {})
      .done(process => {
        // Now you can do it on android.
        const {location} = process;
      })
```