### PR TITLE
Unable to re-download error on ios platform.

### DIFF
--- a/ios/RNBackgroundDownloader.m
+++ b/ios/RNBackgroundDownloader.m
@@ -65,8 +65,8 @@ RCT_EXPORT_MODULE();
         idToResumeDataMap= [[NSMutableDictionary alloc] init];
         idToPercentMap = [[NSMutableDictionary alloc] init];
         NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-        NSString *sessonIdentifier = [bundleIdentifier stringByAppendingString:@".backgrounddownloadtask"];
-        sessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessonIdentifier];
+        NSString *sessionIdentifier = [bundleIdentifier stringByAppendingString:@".backgrounddownloadtask"];
+        sessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionIdentifier];
         sessionConfig.HTTPMaximumConnectionsPerHost = 4;
         sessionConfig.timeoutIntervalForRequest = 60 * 60; // MAX TIME TO GET NEW DATA IN REQUEST - 1 HOUR
         sessionConfig.timeoutIntervalForResource = 60 * 60 * 24; // MAX TIME TO DOWNLOAD RESOURCE - 1 DAY
@@ -166,8 +166,8 @@ RCT_EXPORT_MODULE();
 + (void)setCompletionHandlerWithIdentifier: (NSString *)identifier completionHandler: (CompletionHandler)completionHandler {
     NSLog(@"[RNBackgroundDownloader] - [setCompletionHandlerWithIdentifier]");
     NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-    NSString *sessonIdentifier = [bundleIdentifier stringByAppendingString:@".backgrounddownloadtask"];
-    if ([sessonIdentifier isEqualToString:identifier]) {
+    NSString *sessionIdentifier = [bundleIdentifier stringByAppendingString:@".backgrounddownloadtask"];
+    if ([sessionIdentifier isEqualToString:identifier]) {
         storedCompletionHandler = completionHandler;
     }
 }


### PR DESCRIPTION
If you renew your simulator after downloading once on the Ios platform, you will not be able to download. This is because it is an nsurlsession with the same id. And on the native side you get the error; "nsurlsession already exists".

There is a dealloc function in the package to free resources. But this can't stop "nsurlsession".

This required a configuration that could smoothly restart the download by ios. [https://github.com/itinance/react-native-fs/blob/master/Downloader.m#L53-L54](https://github.com/itinance/react-native-fs/blob/master/Downloader.m#L53-L54)

It now works successfully with my simulator and real device tests. I don't know if creating nsurlsession with UUID will cause any memory leaks. What is your opinion?

**Native Side Logs**
<details><summary>SHOW</summary>
<p>

```ruby
2022-12-15 13:18:11.365639+0300 AudioGuide[9814:93053] [RNBackgroundDownloader] - [init]
2022-12-15 13:18:11.410320+0300 AudioGuide[9814:100121] [RNBackgroundDownloader] - [dealloc]
2022-12-15 13:09:10.344783+0300 AudioGuide[9814:94989] [RNBackgroundDownloader] - [download]
2022-12-15 13:09:10.344959+0300 AudioGuide[9814:94989] [RNBackgroundDownloader] - [lazyInitSession]
2022-12-15 13:09:10.345243+0300 AudioGuide[9814:94989] A background URLSession with identifier com.example.AudioGuide.backgrounddownloadtask already exists!
```

</p>
</details>

**Example:**

https://user-images.githubusercontent.com/36919703/208074602-1069a595-eef7-4eba-baa8-ba187061a847.mp4

