### PR TITLE
Version lock mmkv gradle dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,6 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.tencent:mmkv:+'
+    implementation 'com.tencent:mmkv:1.3.4'
     implementation 'com.google.code.gson:gson:+'
 }


### PR DESCRIPTION
## Purpose

Recently a large number of Android devices have been unable to load the libmmkv library (`java.lang.UnsatisfiedLinkError: dlopen failed: library "libmmkv.so" not found`). 

Last week (04/24) MMKV released v1.3.5 which [dropped armv7 and x86 support](https://github.com/Tencent/MMKV/compare/v1.3.4...v1.3.5#diff-39de3e472b7aa02894eacd44560131bbd4f879e990259c9ce5ff713e0f1c6748R15). The `@kesha-antonov/react-native-background-downloader` package defines a wildcard version using `implementation 'com.tencent:mmkv:+'` which automatically grabbed this update leading to a number of Android devices in production to crash on app start.

The `armv7` abi removed is for 32-bit devices with most modern devices being `arm64-v8a`, 64 bit arch. This PR version locks `com.tencent:mmkv` to v1.3.4, the last stable version with all abi support.

## Deployment
By locking the mmkv version to 1.3.4 and releasing a new npm package version this will allow devices to continue with stable support. Future version of this package can then bump to 1.3.5 and beyond with the developer being able to change their `@kesha-antonov/react-native-background-downloader` version for their needs rather than relying on downstream resolutions.


<details>
<summary>Stacktrace</summary>

```Java
java.lang.UnsatisfiedLinkError: dlopen failed: library "libmmkv.so" not found
        at java.lang.Runtime.loadLibrary0(Runtime.java:1082)
        at java.lang.Runtime.loadLibrary0(Runtime.java:1003)
        at java.lang.System.loadLibrary(System.java:1661)
        at com.tencent.mmkv.MMKV.doInitialize(MMKV.java:226)
        at com.tencent.mmkv.MMKV.initialize(MMKV.java:208)
        at com.tencent.mmkv.MMKV.initialize(MMKV.java:94)
        at com.eko.RNBackgroundDownloaderModule.<init>(RNBackgroundDownloaderModule.java:172)
        at com.eko.RNBackgroundDownloaderPackage.createNativeModules(RNBackgroundDownloaderPackage.java:15)
        at com.facebook.react.ReactPackageHelper.getNativeModuleIterator(ReactPackageHelper.java:43)
        at com.facebook.react.NativeModuleRegistryBuilder.processPackage(NativeModuleRegistryBuilder.java:42)
        at com.facebook.react.ReactInstanceManager.processPackage(ReactInstanceManager.java:1458)
        at com.facebook.react.ReactInstanceManager.processPackages(ReactInstanceManager.java:1429)
        at com.facebook.react.ReactInstanceManager.createReactContext(ReactInstanceManager.java:1331)
        at com.facebook.react.ReactInstanceManager.lambda$runCreateReactContextOnNewThread$2(ReactInstanceManager.java:1101)
        at com.facebook.react.ReactInstanceManager.$r8$lambda$AwGS8CysOZmWJw3kRVARHQvw9Ew(Unknown)
        at com.facebook.react.ReactInstanceManager$$ExternalSyntheticLambda5.run(Unknown:4)
        at java.lang.Thread.run(Thread.java:1012)
```

</details>