### PR TITLE
Pass notification title to android module

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ An object containing options properties
 | `isAllowedOverRoaming` | Boolean   |          |  Android  | whether this download may proceed over a roaming connection. By default, roaming is allowed |
 | `isAllowedOverMetered` | Boolean   |          |  Android  | Whether this download may proceed over a metered network connection. By default, metered networks are allowed |
 | `isNotificationVisible`     | Boolean   |          |  Android  | Whether to show a download notification or not |
+| `notificationTitle`     | String   |          |  Android  | Title of the download notification |
 
 **returns**
 

--- a/android/src/main/java/com/eko/RNBGDTaskConfig.java
+++ b/android/src/main/java/com/eko/RNBGDTaskConfig.java
@@ -7,13 +7,15 @@ public class RNBGDTaskConfig implements Serializable {
     public String url;
     public String destination;
     public String metadata = "{}";
+    public String notificationTitle;
     public boolean reportedBegin;
 
-    public RNBGDTaskConfig(String id, String url, String destination, String metadata) {
+    public RNBGDTaskConfig(String id, String url, String destination, String metadata, String notificationTitle) {
         this.id = id;
         this.url = url;
         this.destination = destination;
         this.metadata = metadata;
+        this.notificationTitle = notificationTitle;
         this.reportedBegin = false;
     }
 }

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -258,6 +258,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule {
     String destination = options.getString("destination");
     ReadableMap headers = options.getMap("headers");
     String metadata = options.getString("metadata");
+    String notificationTitle = options.getString("notificationTitle");
     int progressIntervalScope = options.getInt("progressInterval");
     if (progressIntervalScope > 0) {
       progressInterval = progressIntervalScope;
@@ -281,6 +282,10 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule {
       request.setRequiresCharging(false);
     }
 
+    if (notificationTitle != null) {
+      request.setTitle(notificationTitle);
+    }
+
     if (headers != null) {
       ReadableMapKeySetIterator iterator = headers.keySetIterator();
       while (iterator.hasNextKey()) {
@@ -295,7 +300,7 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule {
     request.setDestinationInExternalFilesDir(this.getReactApplicationContext(), null, filename);
 
     long downloadId = downloader.download(request);
-    RNBGDTaskConfig config = new RNBGDTaskConfig(id, url, destination, metadata);
+    RNBGDTaskConfig config = new RNBGDTaskConfig(id, url, destination, metadata, notificationTitle);
 
     synchronized (sharedLock) {
       configIdToDownloadId.put(id, downloadId);

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,7 @@ export interface DownloadOption {
   isAllowedOverRoaming?: boolean;
   isAllowedOverMetered?: boolean;
   isNotificationVisible?: boolean;
+  notificationTitle?: string;
 }
 
 export type Download = (options: DownloadOption) => DownloadTask;

--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,6 @@ export function download (options: DownloadOptions) {
 
   RNBackgroundDownloader.download({
     ...options,
-    notificationTitle: options.notificationTitle,
     metadata: JSON.stringify(options.metadata),
     progressInterval: config.progressInterval,
   })

--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,7 @@ type DownloadOptions = {
   isAllowedOverRoaming?: boolean,
   isAllowedOverMetered?: boolean,
   isNotificationVisible?: boolean;
+  notificationTitle?: string,
 }
 
 export function download (options: DownloadOptions) {
@@ -148,6 +149,7 @@ export function download (options: DownloadOptions) {
 
   RNBackgroundDownloader.download({
     ...options,
+    notificationTitle: options.notificationTitle,
     metadata: JSON.stringify(options.metadata),
     progressInterval: config.progressInterval,
   })


### PR DESCRIPTION
Thanks for the amazing library and maintenance!
I want to add a prop to pass the notification title to Download Manager. On my Android device (Xiaomi 11 Ultra), if `isNotificationVisible === true`, when the download starts, the notification from the Download Manager is shown as "untitled" and then the title changes to a random number like "2346436.".
With the new `notificationTitle` prop, we can pass the title of the file explicitly to the Download Manager to show it both in the notification drawer and the download list.

![telegram-cloud-photo-size-2-5415886020488062830-y](https://github.com/user-attachments/assets/7fea1681-a87d-4ac1-bd0f-5e666d16e503)
