### PR TITLE
feat(android): add useTempFile option to optimize storage usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ task.resume()
 task.stop()
 ```
 
+### Storage optimization for large files (Android)
+
+By default, downloads on Android use a temporary file before moving to the final destination. This ensures atomic operations but requires double the storage space during download, temporarily. For very large files, you can optimize storage usage by downloading directly to the destination:
+
+```javascript
+let task = download({
+  id: 'large-model',
+  url: 'https://example.com/large-model.gguf',
+  destination: `${directories.documents}/models/large-model.gguf`,
+  useTempFile: false // Download directly to destination
+})
+```
+
+**Note:** When `useTempFile` is `false`, interrupted downloads may leave partial files at the destination. Only use this option when you:
+- Are downloading very large files
+- Have limited storage space
+- Can handle partial files in your application logic
+
 ### Re-Attaching to background downloads
 
 This is the main selling point of this library (but it's free!).
@@ -215,6 +233,7 @@ An object containing options properties
 | `isAllowedOverMetered` | Boolean   |          |  Android  | Whether this download may proceed over a metered network connection. By default, metered networks are allowed |
 | `isNotificationVisible`     | Boolean   |          |  Android  | Whether to show a download notification or not |
 | `notificationTitle`     | String   |          |  Android  | Title of the download notification |
+| `useTempFile`     | Boolean   |          |  Android  | Whether to download to a temporary file first before moving to final destination. By default is `true`. When `false`, downloads directly to destination which saves storage space but may leave partial files if download fails |
 
 **returns**
 

--- a/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
+++ b/android/src/main/java/com/eko/RNBackgroundDownloaderModule.java
@@ -282,6 +282,20 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule {
       request.setRequiresCharging(false);
     }
 
+    boolean useTempFile = true; // Default to true 
+    if (options.hasKey("useTempFile")) {
+        useTempFile = options.getBoolean("useTempFile");
+    }
+
+    if (!useTempFile) {
+        request.setDestinationUri(Uri.parse(destination));
+    } else {
+        int uuid = (int) (System.currentTimeMillis() & 0xfffffff);
+        String extension = MimeTypeMap.getFileExtensionFromUrl(destination);
+        String filename = uuid + "." + extension;
+        request.setDestinationInExternalFilesDir(this.getReactApplicationContext(), null, filename);
+    }
+
     if (notificationTitle != null) {
       request.setTitle(notificationTitle);
     }
@@ -293,11 +307,6 @@ public class RNBackgroundDownloaderModule extends ReactContextBaseJavaModule {
         request.addRequestHeader(headerKey, headers.getString(headerKey));
       }
     }
-
-    int uuid = (int) (System.currentTimeMillis() & 0xfffffff);
-    String extension = MimeTypeMap.getFileExtensionFromUrl(destination);
-    String filename = uuid + "." + extension;
-    request.setDestinationInExternalFilesDir(this.getReactApplicationContext(), null, filename);
 
     long downloadId = downloader.download(request);
     RNBGDTaskConfig config = new RNBGDTaskConfig(id, url, destination, metadata, notificationTitle);

--- a/index.ts
+++ b/index.ts
@@ -119,9 +119,10 @@ type DownloadOptions = {
   destination: string,
   headers?: object,
   metadata?: object,
+  useTempFile?: boolean,
   isAllowedOverRoaming?: boolean,
   isAllowedOverMetered?: boolean,
-  isNotificationVisible?: boolean;
+  isNotificationVisible?: boolean,
   notificationTitle?: string,
 }
 


### PR DESCRIPTION
## Description
This PR adds a new `useTempFile` option to optimize storage usage when downloading large files on Android.

### Key Changes
- Added `useTempFile` boolean option to download configuration
- When `false` (default is `true`), downloads directly to destination instead of using temporary file

### Use case
When downloading very large files (e.g., ML models such as GGUFs), the default approach of using a temporary file requires double the storage space since the file exists in both temporary and final locations during the move operation. This change allows direct downloads to the destination when storage optimization is needed.

Note: Default behavior (using temp file) remains unchanged

Fixes #42 

### Example

```javascript
download({
id: 'large-model',
url: 'https://example.com/large-model.gguf',
destination: ${directories.documents}/models/large-model.gguf,
useTempFile: false // Download directly to destination
})
```

### Platform Affected

- [ ] iOS
- [x] Android

### Checklist
 
- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
    - [ ] iOS Simulator/Device
    - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.

