### PR TITLE
feat(android): persistent completion notification, cancel action, and custom title

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -34,6 +34,21 @@
         <action android:name="com.eko.uidt.ACTION_CANCEL_DOWNLOAD" />
       </intent-filter>
     </receiver>
+
+    <!-- Library-owned FileProvider so tapping the "download complete"
+         notification can open the saved file via the system viewer with no
+         host-app configuration. A dedicated subclass + unique authority avoid
+         manifest-merger / authority collisions with the host app's own
+         FileProvider. -->
+    <provider
+      android:name=".uidt.RNBGDFileProvider"
+      android:authorities="${applicationId}.rnbackgrounddownloader.fileprovider"
+      android:exported="false"
+      android:grantUriPermissions="true">
+      <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/rnbgd_file_paths" />
+    </provider>
   </application>
 
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -25,6 +25,15 @@
       android:name=".UIDTDownloadJobService"
       android:permission="android.permission.BIND_JOB_SERVICE"
       android:exported="false" />
+
+    <!-- Receiver for the in-notification "Cancel" action -->
+    <receiver
+      android:name=".uidt.CancelDownloadReceiver"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="com.eko.uidt.ACTION_CANCEL_DOWNLOAD" />
+      </intent-filter>
+    </receiver>
   </application>
 
 </manifest>

--- a/android/src/main/java/com/eko/UIDTDownloadJobService.kt
+++ b/android/src/main/java/com/eko/UIDTDownloadJobService.kt
@@ -155,12 +155,14 @@ class UIDTDownloadJobService : JobService() {
         val metadataJson = extras.getString(UIDTConstants.KEY_METADATA) ?: "{}"
         var groupId = ""
         var groupName = ""
+        var customTitle = ""
         RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "onStartJob: configId=$configId, metadataJson=$metadataJson")
         try {
             val json = JSONObject(metadataJson)
             groupId = json.optString("groupId", "")
             groupName = json.optString("groupName", "")
-            RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "Parsed metadata: groupId='$groupId', groupName='$groupName'")
+            customTitle = json.optString("notificationTitle", "")
+            RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "Parsed metadata: groupId='$groupId', groupName='$groupName', customTitle='$customTitle'")
         } catch (e: Exception) {
             RNBackgroundDownloaderModuleImpl.logE(UIDTConstants.TAG, "Failed to parse metadata: ${e.message}")
         }
@@ -198,7 +200,7 @@ class UIDTDownloadJobService : JobService() {
 
         // Create notification for UIDT job (required)
         val notificationId = UIDTNotificationManager.getNotificationIdForConfig(configId)
-        val notification = UIDTNotificationManager.createDownloadNotification(this, configId, groupId, groupName)
+        val notification = UIDTNotificationManager.createDownloadNotification(this, configId, groupId, groupName, customTitle)
 
         // Set the notification for this job (required for UIDT)
         setNotification(params, notificationId, notification, JOB_END_NOTIFICATION_POLICY_DETACH)
@@ -215,7 +217,7 @@ class UIDTDownloadJobService : JobService() {
         }
 
         // Store job state BEFORE updating summary (so count includes this job)
-        UIDTJobRegistry.activeJobs[configId] = JobState(params, resumableDownloader, notificationId, groupId, groupName)
+        UIDTJobRegistry.activeJobs[configId] = JobState(params, resumableDownloader, notificationId, groupId, groupName, customTitle)
 
         // Update summary notification if grouping enabled (now includes new job in count)
         UIDTNotificationManager.updateSummaryNotificationForGroup(this, groupId, groupName)

--- a/android/src/main/java/com/eko/UIDTDownloadJobService.kt
+++ b/android/src/main/java/com/eko/UIDTDownloadJobService.kt
@@ -363,6 +363,27 @@ class UIDTDownloadJobService : JobService() {
 
                 RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "onComplete: notificationId=$notificationId, jobState groupId=${jobState?.groupId}")
 
+                // Resolve a display name for the completion notification.
+                // Prefer metadata.fileName (set from JS), fall back to the
+                // saved file's basename.
+                val displayName = try {
+                    val metadataStr = params.extras.getString(UIDTConstants.KEY_METADATA) ?: "{}"
+                    val metadata = JSONObject(metadataStr)
+                    metadata.optString("fileName", "").ifEmpty { location.substringAfterLast('/') }
+                } catch (e: Exception) {
+                    location.substringAfterLast('/')
+                }
+
+                // Post a standalone "download complete" notification BEFORE
+                // we tear down the UIDT-controlled one so it persists. Tap
+                // opens the saved file via FileProvider (system file viewer).
+                UIDTNotificationManager.showFinishedNotification(
+                    this@UIDTDownloadJobService,
+                    id,
+                    location,
+                    displayName,
+                )
+
                 // Clean up - remove from activeJobs first
                 UIDTJobRegistry.activeJobs.remove(id)
                 releaseWakeLock()

--- a/android/src/main/java/com/eko/UIDTDownloadJobService.kt
+++ b/android/src/main/java/com/eko/UIDTDownloadJobService.kt
@@ -295,7 +295,7 @@ class UIDTDownloadJobService : JobService() {
                 if (jobState != null) {
                     // Store total bytes for summary progress calculation
                     jobState.bytesTotal = expectedBytes
-                    UIDTNotificationManager.updateProgressNotification(this@UIDTDownloadJobService, jobState, 0, expectedBytes)
+                    UIDTNotificationManager.updateProgressNotification(this@UIDTDownloadJobService, id, jobState, 0, expectedBytes)
                 }
 
                 // Notify external listener
@@ -346,7 +346,7 @@ class UIDTDownloadJobService : JobService() {
                             } else {
                                 // Update individual notification
                                 UIDTNotificationManager.updateProgressNotification(
-                                    this@UIDTDownloadJobService, jobState, bytesDownloaded, bytesTotal
+                                    this@UIDTDownloadJobService, id, jobState, bytesDownloaded, bytesTotal
                                 )
                             }
                         }

--- a/android/src/main/java/com/eko/uidt/CancelDownloadReceiver.kt
+++ b/android/src/main/java/com/eko/uidt/CancelDownloadReceiver.kt
@@ -24,11 +24,16 @@ class CancelDownloadReceiver : BroadcastReceiver() {
             UIDTConstants.TAG,
             "CancelDownloadReceiver: cancelling $configId",
         )
-        UIDTJobManager.cancelJob(context, configId)
+        val cancelled = UIDTJobManager.cancelJob(context, configId)
 
-        // Notify JS so the in-memory task map can be cleaned and the
-        // .error() handler runs (lib uses CANCELLED errorCode = -1).
-        UIDTJobRegistry.downloadListener?.onError(configId, "Download cancelled by user", -1)
+        // Only notify JS when a live job was actually cancelled. If the download
+        // already finished there is nothing to clean up, and dispatching here
+        // would emit a spurious downloadFailed for an already-completed task.
+        if (cancelled) {
+            // Notify JS so the in-memory task map can be cleaned and the
+            // .error() handler runs (lib uses CANCELLED errorCode = -1).
+            UIDTJobRegistry.downloadListener?.onError(configId, "Download cancelled by user", -1)
+        }
     }
 
     companion object {

--- a/android/src/main/java/com/eko/uidt/CancelDownloadReceiver.kt
+++ b/android/src/main/java/com/eko/uidt/CancelDownloadReceiver.kt
@@ -1,0 +1,38 @@
+package com.eko.uidt
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.eko.RNBackgroundDownloaderModuleImpl
+
+/**
+ * Receives the cancel action fired from the download progress notification.
+ * The action carries the download's [EXTRA_CONFIG_ID] as a string extra; on
+ * receive we cancel the corresponding UIDT job (which also tears down the
+ * notification) and dispatch a downloadFailed event so JS can clean up.
+ */
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+class CancelDownloadReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_CANCEL_DOWNLOAD) return
+        val configId = intent.getStringExtra(EXTRA_CONFIG_ID) ?: return
+
+        RNBackgroundDownloaderModuleImpl.logD(
+            UIDTConstants.TAG,
+            "CancelDownloadReceiver: cancelling $configId",
+        )
+        UIDTJobManager.cancelJob(context, configId)
+
+        // Notify JS so the in-memory task map can be cleaned and the
+        // .error() handler runs (lib uses CANCELLED errorCode = -1).
+        UIDTJobRegistry.downloadListener?.onError(configId, "Download cancelled by user", -1)
+    }
+
+    companion object {
+        const val ACTION_CANCEL_DOWNLOAD = "com.eko.uidt.ACTION_CANCEL_DOWNLOAD"
+        const val EXTRA_CONFIG_ID = "config_id"
+    }
+}

--- a/android/src/main/java/com/eko/uidt/RNBGDFileProvider.kt
+++ b/android/src/main/java/com/eko/uidt/RNBGDFileProvider.kt
@@ -1,0 +1,17 @@
+package com.eko.uidt
+
+import androidx.core.content.FileProvider
+
+/**
+ * Library-owned [FileProvider] subclass.
+ *
+ * Using a dedicated subclass (rather than registering
+ * `androidx.core.content.FileProvider` directly) gives the provider a unique
+ * component class name. This avoids a manifest-merger collision with a host
+ * app that also declares an `androidx.core.content.FileProvider`, while a
+ * unique authority (`${applicationId}.rnbackgrounddownloader.fileprovider`)
+ * keeps the authority from clashing too.
+ *
+ * Paths it can serve are declared in `res/xml/rnbgd_file_paths.xml`.
+ */
+class RNBGDFileProvider : FileProvider()

--- a/android/src/main/java/com/eko/uidt/UIDTJobManager.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTJobManager.kt
@@ -117,9 +117,13 @@ object UIDTJobManager {
 
     /**
      * Cancel a scheduled UIDT job.
+     *
+     * @return `true` if a live (active) job was found and cancelled, `false`
+     * if there was nothing to cancel (e.g. the download already completed).
+     * Callers can use this to avoid dispatching a spurious downloadFailed event.
      */
-    fun cancelJob(context: Context, configId: String) {
-        if (!isUIDTAvailable()) return
+    fun cancelJob(context: Context, configId: String): Boolean {
+        if (!isUIDTAvailable()) return false
 
         RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "cancelJob called for $configId")
 
@@ -167,6 +171,7 @@ object UIDTJobManager {
         }
 
         RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "Cancelled UIDT job for $configId")
+        return jobState != null
     }
 
     /**

--- a/android/src/main/java/com/eko/uidt/UIDTJobState.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTJobState.kt
@@ -106,6 +106,11 @@ object UIDTConstants {
     // Notification channel for UIDT jobs (ultra-silent for summaryOnly mode)
     const val NOTIFICATION_CHANNEL_ULTRA_SILENT_ID = "uidt_download_channel_ultra_silent"
 
+    // Notification channel for the one-shot "download complete" notification.
+    // Uses IMPORTANCE_DEFAULT so completion is actually surfaced to the user
+    // (the progress channel is IMPORTANCE_LOW and never alerts).
+    const val NOTIFICATION_CHANNEL_FINISHED_ID = "uidt_download_channel_finished"
+
     // Notification group for grouping all download notifications together
     const val NOTIFICATION_GROUP_KEY = "com.eko.DOWNLOAD_GROUP"
 

--- a/android/src/main/java/com/eko/uidt/UIDTJobState.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTJobState.kt
@@ -16,6 +16,9 @@ data class JobState(
     var notificationId: Int,
     val groupId: String = "",
     val groupName: String = "",
+    // Optional per-download notification title (read from metadata.notificationTitle).
+    // When non-empty, overrides both groupName and the config's default downloadTitle.
+    val customTitle: String = "",
     var lastNotifiedProgress: Int = -1,
     var lastNotificationUpdateTime: Long = 0,
     // Track download progress for summary notification

--- a/android/src/main/java/com/eko/uidt/UIDTJobState.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTJobState.kt
@@ -114,6 +114,12 @@ object UIDTConstants {
 
     // Base for individual notification IDs
     const val NOTIFICATION_ID_BASE = 20000
+
+    // Base for one-shot "download complete" notification IDs. Kept in a
+    // disjoint range from NOTIFICATION_ID_BASE (which spans 20000..119999 via
+    // hash % 100000) so a finished notification can never collide with another
+    // download's in-progress notification.
+    const val FINISHED_NOTIFICATION_ID_BASE = 200000
 }
 
 /**

--- a/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
@@ -37,6 +37,15 @@ object UIDTNotificationManager {
     }
 
     /**
+     * Stable notification ID for the one-shot "download complete" notification.
+     * Lives in a disjoint range from [getNotificationIdForConfig] so it can
+     * never collide with another download's in-progress notification.
+     */
+    fun getFinishedNotificationIdForConfig(configId: String): Int {
+        return UIDTConstants.FINISHED_NOTIFICATION_ID_BASE + (configId.hashCode() and 0x7FFFFFFF) % 100000
+    }
+
+    /**
      * Create notification channels for UIDT jobs.
      * Must be called before showing any notifications (typically in service onCreate).
      */
@@ -580,9 +589,10 @@ object UIDTNotificationManager {
         createNotificationChannels(context)
 
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        // Use a distinct id from the in-progress one to avoid being removed by the
-        // REMOVE policy applied to the ongoing notification.
-        val notificationId = getNotificationIdForConfig(configId) + 1
+        // Use an id from a disjoint range so it is neither removed by the REMOVE
+        // policy applied to the ongoing notification nor collides with another
+        // download's in-progress notification.
+        val notificationId = getFinishedNotificationIdForConfig(configId)
 
         val title = config.getText("downloadFinished")
 

--- a/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
@@ -3,14 +3,19 @@ package com.eko.uidt
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.job.JobService
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import androidx.core.content.FileProvider
 import com.eko.RNBackgroundDownloaderModuleImpl
 import com.eko.UIDTDownloadJobService
 import com.eko.utils.ProgressUtils
+import java.io.File
+import java.net.URLConnection
 
 /**
  * Manages all notification-related operations for UIDT downloads.
@@ -513,5 +518,72 @@ object UIDTNotificationManager {
             .setContentText("")
             .setSmallIcon(android.R.drawable.stat_sys_download)
             .build()
+    }
+
+    /**
+     * Show a one-shot "download complete" notification that persists after the
+     * UIDT job is removed by the system. Uses the configured "downloadFinished"
+     * text as the title and the supplied [fileName] as the body. Posted via
+     * NotificationManager (not tied to the JobService) so it survives the
+     * service shutdown.
+     *
+     * Tapping the notification fires ACTION_VIEW with a FileProvider content
+     * URI for [destination] so the system file viewer / Files app can open it.
+     */
+    fun showFinishedNotification(
+        context: Context,
+        configId: String,
+        destination: String,
+        fileName: String,
+    ) {
+        if (!config.showNotificationsEnabled) return
+
+        createNotificationChannels(context)
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        // Use a distinct id from the in-progress one to avoid being removed by the
+        // REMOVE policy applied to the ongoing notification.
+        val notificationId = getNotificationIdForConfig(configId) + 1
+
+        val title = config.getText("downloadFinished")
+
+        // Build a PendingIntent that lets the user open the saved file with the
+        // system viewer (Files app / Drive / Extract...). Uses the host app's
+        // FileProvider authority (".provider") which is registered via the
+        // bundled react-native-file-viewer-turbo manifest.
+        val pendingIntent: PendingIntent? = try {
+            val file = File(destination)
+            val authority = "${context.packageName}.provider"
+            val uri = FileProvider.getUriForFile(context, authority, file)
+            val mime = URLConnection.guessContentTypeFromName(fileName) ?: "*/*"
+            val viewIntent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, mime)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            val chooser = Intent.createChooser(viewIntent, title).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            PendingIntent.getActivity(
+                context,
+                notificationId,
+                chooser,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        } catch (e: Exception) {
+            RNBackgroundDownloaderModuleImpl.logW(UIDTConstants.TAG, "Failed to build pendingIntent for finished noti: ${e.message}")
+            null
+        }
+
+        val builder = NotificationCompat.Builder(context, UIDTConstants.NOTIFICATION_CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(fileName)
+            .setSmallIcon(android.R.drawable.stat_sys_download_done)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+        if (pendingIntent != null) builder.setContentIntent(pendingIntent)
+
+        notificationManager.notify(notificationId, builder.build())
+        RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "Posted finished notification $notificationId for $configId")
     }
 }

--- a/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
@@ -8,6 +8,7 @@ import android.app.job.JobService
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -604,14 +605,15 @@ object UIDTNotificationManager {
         val title = config.getText("downloadFinished")
 
         // Build a PendingIntent that lets the user open the saved file with the
-        // system viewer (Files app / Drive / Extract...). The FileProvider
-        // authority is auto-detected from the host app's manifest (see
-        // resolveFileProviderAuthority); if no provider is registered the tap
-        // action is simply omitted and the notification is still posted.
+        // system viewer (Files app / Drive / Extract...). We resolve the file
+        // through the library-owned FileProvider first (declared in this
+        // library's manifest, so it works with no host-app configuration) and
+        // only fall back to auto-detecting a host-app provider if that fails.
+        // If neither produces a URI the tap action is simply omitted and the
+        // notification is still posted.
         val pendingIntent: PendingIntent? = try {
             val file = File(destination)
-            val authority = resolveFileProviderAuthority(context)
-            val uri = FileProvider.getUriForFile(context, authority, file)
+            val uri = resolveContentUri(context, file)
             val mime = URLConnection.guessContentTypeFromName(fileName) ?: "*/*"
             val viewIntent = Intent(Intent.ACTION_VIEW).apply {
                 setDataAndType(uri, mime)
@@ -645,10 +647,37 @@ object UIDTNotificationManager {
     }
 
     /**
+     * Resolve a content:// URI for [file], preferring this library's own
+     * FileProvider (authority "${packageName}.rnbackgrounddownloader.fileprovider",
+     * declared in the library manifest with [RNBGDFileProvider] +
+     * rnbgd_file_paths.xml) so tap-to-open works with no host-app setup.
+     *
+     * If the file falls outside the library provider's configured roots — e.g.
+     * a consumer downloads to a directory not covered by rnbgd_file_paths.xml —
+     * fall back to auto-detecting a host-app FileProvider authority. Throws if
+     * neither can serve the file; the caller catches and omits the tap action.
+     */
+    private fun resolveContentUri(context: Context, file: File): Uri {
+        val libraryAuthority = "${context.packageName}.rnbackgrounddownloader.fileprovider"
+        return try {
+            FileProvider.getUriForFile(context, libraryAuthority, file)
+        } catch (e: IllegalArgumentException) {
+            // File not under any root declared in rnbgd_file_paths.xml; try a
+            // host-app provider as a secondary path.
+            RNBackgroundDownloaderModuleImpl.logW(
+                UIDTConstants.TAG,
+                "Library FileProvider can't serve $file (${e.message}); trying host-app provider",
+            )
+            val fallbackAuthority = resolveFileProviderAuthority(context)
+            FileProvider.getUriForFile(context, fallbackAuthority, file)
+        }
+    }
+
+    /**
      * Resolve the host app's FileProvider authority at runtime by scanning the
      * providers registered in its manifest, rather than assuming a fixed
-     * "${packageName}.provider". This lets the tap-to-open action work for any
-     * consumer regardless of how their FileProvider is named.
+     * "${packageName}.provider". Used only as a secondary fallback when the
+     * library-owned provider cannot serve a file (see [resolveContentUri]).
      *
      * Preference order: an authority equal to "${packageName}.provider", then
      * any authority owned by this package, then the conventional default as a
@@ -658,6 +687,8 @@ object UIDTNotificationManager {
     private fun resolveFileProviderAuthority(context: Context): String {
         val packageName = context.packageName
         val default = "$packageName.provider"
+        // Skip our own provider — resolveContentUri already tried it.
+        val libraryAuthority = "$packageName.rnbackgrounddownloader.fileprovider"
         return try {
             val flags = PackageManager.GET_PROVIDERS
             val providers = context.packageManager
@@ -666,6 +697,7 @@ object UIDTNotificationManager {
                 ?.filter { it.name == "androidx.core.content.FileProvider" || it.name.endsWith("FileProvider") }
                 ?.mapNotNull { it.authority }
                 ?.flatMap { it.split(';') }
+                ?.filter { it != libraryAuthority }
                 ?: emptyList()
 
             providers.firstOrNull { it == default }

--- a/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
@@ -83,13 +83,36 @@ object UIDTNotificationManager {
     }
 
     /**
+     * Build a PendingIntent that fires the in-notification "Cancel" action.
+     * The receiver lives in [CancelDownloadReceiver] and calls
+     * [UIDTJobManager.cancelJob] when triggered.
+     */
+    private fun buildCancelPendingIntent(context: Context, configId: String): PendingIntent {
+        val intent = Intent(context, CancelDownloadReceiver::class.java).apply {
+            action = CancelDownloadReceiver.ACTION_CANCEL_DOWNLOAD
+            setPackage(context.packageName)
+            putExtra(CancelDownloadReceiver.EXTRA_CONFIG_ID, configId)
+        }
+        // Use stable notification id as request code so subsequent updates
+        // reuse the same PendingIntent slot.
+        val requestCode = getNotificationIdForConfig(configId)
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    /**
      * Create the initial notification for a download.
      */
     fun createDownloadNotification(
         context: Context,
         configId: String,
         groupId: String = "",
-        groupName: String = ""
+        groupName: String = "",
+        customTitle: String = ""
     ): Notification {
         val isSummaryOnlyMode = config.mode == NotificationGroupingMode.SUMMARY_ONLY
 
@@ -128,10 +151,10 @@ object UIDTNotificationManager {
                 .build()
         }
 
-        val title = if (config.groupingEnabled && groupName.isNotEmpty()) {
-            groupName
-        } else {
-            config.getText("downloadTitle")
+        val title = when {
+            customTitle.isNotEmpty() -> customTitle
+            config.groupingEnabled && groupName.isNotEmpty() -> groupName
+            else -> config.getText("downloadTitle")
         }
         val startingText = config.getText("downloadStarting")
 
@@ -144,6 +167,11 @@ object UIDTNotificationManager {
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
             .setProgress(0, 0, true)
+            .addAction(
+                android.R.drawable.ic_menu_close_clear_cancel,
+                context.getString(android.R.string.cancel),
+                buildCancelPendingIntent(context, configId),
+            )
 
         // Apply grouping when enabled and groupId is provided
         if (config.groupingEnabled && groupId.isNotEmpty()) {
@@ -178,13 +206,16 @@ object UIDTNotificationManager {
 
         val progress = ProgressUtils.calculateProgress(bytesDownloaded, bytesTotal)
 
-        val title = if (config.groupingEnabled && jobState.groupName.isNotEmpty()) {
-            jobState.groupName
-        } else {
-            config.getText("downloadTitle")
+        val title = when {
+            jobState.customTitle.isNotEmpty() -> jobState.customTitle
+            config.groupingEnabled && jobState.groupName.isNotEmpty() -> jobState.groupName
+            else -> config.getText("downloadTitle")
         }
 
         val progressText = config.getText("downloadProgress", "progress" to progress)
+
+        val configId = UIDTJobRegistry.activeJobs.entries
+            .firstOrNull { it.value === jobState }?.key
 
         val builder = NotificationCompat.Builder(context, UIDTConstants.NOTIFICATION_CHANNEL_ID)
             .setContentTitle(title)
@@ -195,6 +226,14 @@ object UIDTNotificationManager {
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
             .setProgress(100, progress, bytesTotal <= 0)
+
+        if (configId != null) {
+            builder.addAction(
+                android.R.drawable.ic_menu_close_clear_cancel,
+                context.getString(android.R.string.cancel),
+                buildCancelPendingIntent(context, configId),
+            )
+        }
 
         // Apply grouping when enabled
         if (config.groupingEnabled && jobState.groupId.isNotEmpty()) {
@@ -254,10 +293,10 @@ object UIDTNotificationManager {
         // Update tracking state so next onProgress knows current state
         jobState.lastNotifiedProgress = progress
 
-        val title = if (config.groupingEnabled && jobState.groupName.isNotEmpty()) {
-            jobState.groupName
-        } else {
-            config.getText("downloadTitle")
+        val title = when {
+            jobState.customTitle.isNotEmpty() -> jobState.customTitle
+            config.groupingEnabled && jobState.groupName.isNotEmpty() -> jobState.groupName
+            else -> config.getText("downloadTitle")
         }
 
         val builder = NotificationCompat.Builder(context, UIDTConstants.NOTIFICATION_CHANNEL_ID)

--- a/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
+++ b/android/src/main/java/com/eko/uidt/UIDTNotificationManager.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.job.JobService
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -88,6 +89,17 @@ object UIDTNotificationManager {
                 setSound(null, null)
             }
             notificationManager.createNotificationChannel(ultraSilentChannel)
+
+            // Channel for the one-shot "download complete" notification
+            // (IMPORTANCE_DEFAULT so it actually alerts, unlike the progress channel)
+            val finishedChannel = NotificationChannel(
+                UIDTConstants.NOTIFICATION_CHANNEL_FINISHED_ID,
+                "Download Complete",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Notifies when a background download has finished"
+            }
+            notificationManager.createNotificationChannel(finishedChannel)
         }
     }
 
@@ -196,6 +208,7 @@ object UIDTNotificationManager {
      */
     fun updateProgressNotification(
         context: Context,
+        configId: String,
         jobState: JobState,
         bytesDownloaded: Long,
         bytesTotal: Long
@@ -223,9 +236,6 @@ object UIDTNotificationManager {
 
         val progressText = config.getText("downloadProgress", "progress" to progress)
 
-        val configId = UIDTJobRegistry.activeJobs.entries
-            .firstOrNull { it.value === jobState }?.key
-
         val builder = NotificationCompat.Builder(context, UIDTConstants.NOTIFICATION_CHANNEL_ID)
             .setContentTitle(title)
             .setContentText(progressText)
@@ -235,14 +245,11 @@ object UIDTNotificationManager {
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
             .setProgress(100, progress, bytesTotal <= 0)
-
-        if (configId != null) {
-            builder.addAction(
+            .addAction(
                 android.R.drawable.ic_menu_close_clear_cancel,
                 context.getString(android.R.string.cancel),
                 buildCancelPendingIntent(context, configId),
             )
-        }
 
         // Apply grouping when enabled
         if (config.groupingEnabled && jobState.groupId.isNotEmpty()) {
@@ -597,12 +604,13 @@ object UIDTNotificationManager {
         val title = config.getText("downloadFinished")
 
         // Build a PendingIntent that lets the user open the saved file with the
-        // system viewer (Files app / Drive / Extract...). Uses the host app's
-        // FileProvider authority (".provider") which is registered via the
-        // bundled react-native-file-viewer-turbo manifest.
+        // system viewer (Files app / Drive / Extract...). The FileProvider
+        // authority is auto-detected from the host app's manifest (see
+        // resolveFileProviderAuthority); if no provider is registered the tap
+        // action is simply omitted and the notification is still posted.
         val pendingIntent: PendingIntent? = try {
             val file = File(destination)
-            val authority = "${context.packageName}.provider"
+            val authority = resolveFileProviderAuthority(context)
             val uri = FileProvider.getUriForFile(context, authority, file)
             val mime = URLConnection.guessContentTypeFromName(fileName) ?: "*/*"
             val viewIntent = Intent(Intent.ACTION_VIEW).apply {
@@ -624,7 +632,7 @@ object UIDTNotificationManager {
             null
         }
 
-        val builder = NotificationCompat.Builder(context, UIDTConstants.NOTIFICATION_CHANNEL_ID)
+        val builder = NotificationCompat.Builder(context, UIDTConstants.NOTIFICATION_CHANNEL_FINISHED_ID)
             .setContentTitle(title)
             .setContentText(fileName)
             .setSmallIcon(android.R.drawable.stat_sys_download_done)
@@ -634,5 +642,39 @@ object UIDTNotificationManager {
 
         notificationManager.notify(notificationId, builder.build())
         RNBackgroundDownloaderModuleImpl.logD(UIDTConstants.TAG, "Posted finished notification $notificationId for $configId")
+    }
+
+    /**
+     * Resolve the host app's FileProvider authority at runtime by scanning the
+     * providers registered in its manifest, rather than assuming a fixed
+     * "${packageName}.provider". This lets the tap-to-open action work for any
+     * consumer regardless of how their FileProvider is named.
+     *
+     * Preference order: an authority equal to "${packageName}.provider", then
+     * any authority owned by this package, then the conventional default as a
+     * last resort (which may still throw in getUriForFile if unregistered —
+     * that is caught by the caller).
+     */
+    private fun resolveFileProviderAuthority(context: Context): String {
+        val packageName = context.packageName
+        val default = "$packageName.provider"
+        return try {
+            val flags = PackageManager.GET_PROVIDERS
+            val providers = context.packageManager
+                .getPackageInfo(packageName, flags)
+                .providers
+                ?.filter { it.name == "androidx.core.content.FileProvider" || it.name.endsWith("FileProvider") }
+                ?.mapNotNull { it.authority }
+                ?.flatMap { it.split(';') }
+                ?: emptyList()
+
+            providers.firstOrNull { it == default }
+                ?: providers.firstOrNull { it.startsWith(packageName) }
+                ?: providers.firstOrNull()
+                ?: default
+        } catch (e: Exception) {
+            RNBackgroundDownloaderModuleImpl.logW(UIDTConstants.TAG, "Failed to resolve FileProvider authority: ${e.message}")
+            default
+        }
     }
 }

--- a/android/src/main/res/xml/rnbgd_file_paths.xml
+++ b/android/src/main/res/xml/rnbgd_file_paths.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Paths the library-owned RNBGDFileProvider can expose via getUriForFile.
+
+  Downloads default to the app's internal files dir (documents == filesDir),
+  but consumers may pass any `destination` under the app's private storage, so
+  every app-scoped root is covered. Names are arbitrary URI path segments and
+  do not need to match the host app's own file_paths.xml.
+
+  Only app-scoped roots are declared — the directories this library writes to.
+  Shared/public storage is deliberately not exposed; a download saved outside
+  these roots falls back to a host-app FileProvider (see resolveContentUri).
+-->
+<paths>
+  <!-- context.getFilesDir() — default download location (documents) -->
+  <files-path name="rnbgd_files" path="." />
+  <!-- context.getCacheDir() -->
+  <cache-path name="rnbgd_cache" path="." />
+  <!-- context.getExternalFilesDir(null) -->
+  <external-files-path name="rnbgd_external_files" path="." />
+  <!-- context.getExternalCacheDir() -->
+  <external-cache-path name="rnbgd_external_cache" path="." />
+</paths>

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -77,19 +77,9 @@ const task = createDownloadTask({
 })
 ```
 
-**Tap-to-open (FileProvider):** Tapping the completion notification opens the saved file via a `FileProvider` content URI and the system chooser. The library auto-detects the host app's `FileProvider` authority from its merged manifest — no configuration is required if your app (or one of its dependencies) registers a `FileProvider`. If no `FileProvider` is registered, the notification is still posted, but **without** a tap action (the failure is logged, not thrown). To enable tap-to-open in an app that has no `FileProvider`, register one in your `AndroidManifest.xml`:
+**Tap-to-open (FileProvider):** Tapping the completion notification opens the saved file via a `FileProvider` content URI and the system chooser. This works out of the box with **no configuration** — the library ships its own `FileProvider` (`RNBGDFileProvider`, authority `${applicationId}.rnbackgrounddownloader.fileprovider`) declared in its manifest, covering the app-scoped directories downloads are written to. The unique subclass and authority avoid manifest-merger collisions with any `FileProvider` your app already registers.
 
-```xml
-<provider
-  android:name="androidx.core.content.FileProvider"
-  android:authorities="${applicationId}.provider"
-  android:exported="false"
-  android:grantUriPermissions="true">
-  <meta-data
-    android:name="android.support.FILE_PROVIDER_PATHS"
-    android:resource="@xml/file_provider_paths" />
-</provider>
-```
+If a download is saved to a directory the library's provider does not cover, the library falls back to auto-detecting a host-app `FileProvider` authority from the merged manifest. If neither can serve the file, the notification is still posted, but **without** a tap action (the failure is logged, not thrown).
 
 ### MMKV Dependency
 

--- a/docs/PLATFORM_NOTES.md
+++ b/docs/PLATFORM_NOTES.md
@@ -60,6 +60,37 @@ The library uses a Foreground Service for pause/resume functionality. This requi
 - `FOREGROUND_SERVICE` permission (automatically added)
 - Notification displayed during downloads
 
+### Download Notifications (Android 14+)
+
+On Android 14+ (API 34) downloads run as user-initiated data transfers (UIDT) and the library manages a richer notification flow. These features apply only when `showNotificationsEnabled` is `true`:
+
+- **Cancel action** — the in-progress notification shows a **Cancel** button. Tapping it stops the download, removes the notification, and fires the task's `.error()` handler with `errorCode = -1` (`CANCELLED`).
+- **Completion notification** — when a download finishes, a persistent "download complete" notification is posted on its own `IMPORTANCE_DEFAULT` channel (so it surfaces to the user, unlike the silent progress channel). It uses the `downloadFinished` text as its title.
+- **Per-download title** — pass `metadata.notificationTitle` when creating a task to override the notification title for that download. Precedence: `notificationTitle` → `groupName` (when grouping is enabled) → the default `downloadTitle` text.
+
+```javascript
+const task = createDownloadTask({
+  id: 'file123',
+  url: 'https://example.com/file.mp3',
+  destination: `${directories.documents}/file.mp3`,
+  metadata: { notificationTitle: 'My Custom Title' },
+})
+```
+
+**Tap-to-open (FileProvider):** Tapping the completion notification opens the saved file via a `FileProvider` content URI and the system chooser. The library auto-detects the host app's `FileProvider` authority from its merged manifest — no configuration is required if your app (or one of its dependencies) registers a `FileProvider`. If no `FileProvider` is registered, the notification is still posted, but **without** a tap action (the failure is logged, not thrown). To enable tap-to-open in an app that has no `FileProvider`, register one in your `AndroidManifest.xml`:
+
+```xml
+<provider
+  android:name="androidx.core.content.FileProvider"
+  android:authorities="${applicationId}.provider"
+  android:exported="false"
+  android:grantUriPermissions="true">
+  <meta-data
+    android:name="android.support.FILE_PROVIDER_PATHS"
+    android:resource="@xml/file_provider_paths" />
+</provider>
+```
+
 ### MMKV Dependency
 
 Android uses MMKV for persistent state storage. This is required for:


### PR DESCRIPTION
## Summary

  Three related additions to the Android UIDT notification flow:

  - **Persistent "download complete" notification** — posted via `NotificationManager` so it survives the `JobService` teardown. Tap opens the file through `FileProvider` + `ACTION_VIEW` chooser.
  - **Cancel action** — the in-progress notification shows a "Cancel" button that aborts the download and dispatches an error event to JS for cleanup.
  - **Per-download custom title** — JS can pass `metadata.notificationTitle` to override the notification title for a specific download, taking precedence over `groupName` and the config's default `downloadTitle`.

  ## Motivation

  Previously the ongoing notification was attached to the `JobService` lifecycle and disappeared as soon as the job finished, leaving users with no completion feedback and no quick way to open the result. There was also no way to cancel an
  in-flight download from the notification shade, and no way to customize the notification title per-download.

  ## Changes

  ### Completion notification

  **`UIDTDownloadJobService.kt`** — in `onComplete`, resolve a display name from `metadata.fileName` (fallback: file basename) and call `UIDTNotificationManager.showFinishedNotification(...)` *before* removing the job from `activeJobs` / releasing
  the wake lock.

  **`UIDTNotificationManager.kt`** — new `showFinishedNotification(context, configId, destination, fileName)`:

  - Gated by `config.showNotificationsEnabled`.
  - Posted via `NotificationManager` (not the `JobService`) so it survives service shutdown.
  - Uses a distinct id (`getNotificationIdForConfig(configId) + 1`) to dodge the REMOVE policy applied to the in-progress notification.
  - Title = `config.getText("downloadFinished")`, body = file name.
  - Tap action: `ACTION_VIEW` wrapped in `Intent.createChooser(...)`, backed by a `FileProvider` URI under `${packageName}.provider`, with mime type guessed via `URLConnection.guessContentTypeFromName`.
  - `PendingIntent` construction is wrapped in `try/catch` — on failure the notification is still posted without a tap action.

  ### Cancel action

  **`AndroidManifest.xml`** — register the new `CancelDownloadReceiver` with an intent filter for `com.eko.uidt.ACTION_CANCEL_DOWNLOAD` (not exported).

  **`CancelDownloadReceiver.kt`** (new) — handles the Cancel action: calls `UIDTJobManager.cancelJob(configId)` (which tears down the job + notification) and dispatches `onError(configId, "Download cancelled by user", -1)` so the JS `.error()`
  handler runs with the `CANCELLED` errorCode.

  **`UIDTNotificationManager.kt`** — new `buildCancelPendingIntent(...)` helper targeting `CancelDownloadReceiver` with `FLAG_IMMUTABLE | FLAG_UPDATE_CURRENT`, using the stable notification id as the request code so updates reuse the same slot. The
   initial and progress notifications attach the Cancel action via `addAction(...)`.

  ### Per-download custom title

  **`UIDTDownloadJobService.kt`** — parse `metadata.notificationTitle` in `onStartJob`, pass it into `createDownloadNotification(...)`, and store it on `JobState`.

  **`UIDTJobState.kt`** — add `customTitle: String = ""` field.

  **`UIDTNotificationManager.kt`** — title resolution updated to a three-way precedence: `customTitle` → `groupName` (when grouping enabled) → `config.getText("downloadTitle")`. Applied consistently in the initial, progress, and completion
  notifications.

  ## Test plan

  **Completion notification**
  - [ ] Let a download complete in foreground — completion notification appears and persists after the service stops.
  - [ ] Tap it — system chooser opens and the file can be viewed.
  - [ ] Background the app and complete a download — notification still appears.
  - [ ] Complete downloads for pdf, mp4, zip, and an unknown extension — chooser resolves correctly.
  - [ ] Set `showNotificationsEnabled = false` — no completion notification is posted.
  - [ ] Confirm host app registers `${packageName}.provider` — no `IllegalArgumentException` from `FileProvider.getUriForFile`.

  **Cancel action**
  - [ ] Cancel button is visible on the progress notification.
  - [ ] Tap Cancel — job stops, notification is removed, JS `.error()` fires with `errorCode = -1`.
  - [ ] Tap Cancel after the download has already finished — no crash, no spurious error event.

  **Custom title**
  - [ ] Start with `metadata.notificationTitle: "My Custom Title"` — initial, progress, and completion notifications all show that title.
  - [ ] Start with both `groupName` and `notificationTitle` — `notificationTitle` wins.
  - [ ] Start with neither — default `downloadTitle` is used.
  - [ ] Multiple concurrent downloads with different custom titles — each notification shows its own title; Cancel only affects the targeted job.

  **Compatibility**
  - [ ] Verify on Android 8+, 10, 12, 14 — channel + `PendingIntent.FLAG_IMMUTABLE` behavior is correct.